### PR TITLE
Add `addYears` and `addMonths`

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,14 @@ Returns the difference in days (24 hour periods) between two dates. Excludes wee
 
 Similar to `differenceInDays` however counts all dates that fit into the period, not 24 hour periods.
 
+**`addYears(date, years)`**
+
+Returns a cloned date with years added to it, use negative input for subtraction.
+
+**`addMonths(date, months)`**
+
+Returns a cloned date with months added to it, use negative input for subtraction.
+
 **`addDays(date, days)`**
 
 Returns a cloned date with days added to it, use negative input for subtraction.

--- a/instadate.js
+++ b/instadate.js
@@ -60,6 +60,18 @@ var instadate = {
 
   /* Adding time to dates */
 
+  addYears: function (d, years) {
+    var date = new Date(d);
+    date.setFullYear(date.getFullYear() + years);
+    return date;
+  },
+
+  addMonths: function (d, months) {
+    var date = new Date(d);
+    date.setMonth(date.getMonth() + months);
+    return date;
+  },
+
   addDays: function (d, days) {
     return instadate.addMilliseconds(d, days * constants.MS_IN_DAY);
   },

--- a/test/main.js
+++ b/test/main.js
@@ -27,6 +27,31 @@ test('noon with input date', function (t) {
   t.end();
 });
 
+test('adding years', function (t) {
+  var d = instadate.noon(new Date('Mon Feb 18 2016 13:07:17 GMT+0200 (EET)'));
+  t.equal(d.getFullYear(), 2016);
+  t.equal(instadate.addYears(d, 1).getFullYear(), 2017);
+  t.equal(instadate.addYears(d, -1).getFullYear(), 2015);
+  t.end();
+});
+
+test('adding months', function (t) {
+  var d = instadate.noon(new Date('Mon Feb 18 2016 13:07:17 GMT+0200 (EET)'));
+  t.equal(d.getMonth(), 1);
+  t.equal(instadate.addMonths(d, 1).getMonth(), 2);
+  t.equal(instadate.addMonths(d, -1).getMonth(), 0);
+
+  var date1 = instadate.addMonths(d, 12);
+  t.equal(date1.getMonth(), 1);
+  t.equal(date1.getFullYear(), 2017);
+
+  var date2 = instadate.addMonths(d, -12);
+  t.equal(date2.getMonth(), 1);
+  t.equal(date2.getFullYear(), 2015);
+
+  t.end();
+});
+
 test('adding days', function (t) {
   var d = instadate.noon(new Date('Mon Jan 18 2016 13:07:17 GMT+0200 (EET)'));
   t.equal(d.getDate(), 18);


### PR DESCRIPTION
I'm not sure if you left these out on purpose but I needed them and thought I would add them. I wasn't able to write them using `addMilliseconds` as obviously months and years can have a different amount of milliseconds in them.