### PR TITLE
Better isoDateString

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,7 @@ npm test
 
 ## Changelog
 
+* 0.5.0 - Changed `isoDateString` to work correctly with UTC+13, UTC+14 & UTC-12. Removed `dateString` function.
 * 0.4.0 - Added `parseISOString` and `resetTimezoneOffset` functions
 * 0.3.2 - Performance optimisations. Subtract dates instead of comparing them.
 * 0.3.1 - Modified `addDays`, `addHours`, `addMinutes`, `addSeconds` and `addMilliseconds` functions to work with dayling saving changes.

--- a/instadate.js
+++ b/instadate.js
@@ -145,12 +145,18 @@ var instadate = {
     return result;
   },
 
-  dateString: function (date) {
-    return date.toString().slice(0, 15);
-  },
-
   isoDateString: function (date) {
-    return date.toISOString().slice(0, 10);
+    var year = date.getFullYear();
+    var month = date.getMonth() + 1;
+    var day = date.getDate();
+    if (month < 10) {
+      month = '0' + month;
+    }
+    if (day < 10) {
+      day = '0' + day;
+    }
+
+    return year + '-' + month + '-' + day;
   },
 
   parseISOString: function (isoString) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "instadate",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "A minimal high performance date library for Node.js and Browser",
   "keywords": [
     "instadate",

--- a/test/main.js
+++ b/test/main.js
@@ -283,12 +283,6 @@ test('equal', function (t) {
   t.end();
 });
 
-test('dateString', function (t) {
-  var d = new Date('Mon Jan 18 2016 13:07:17 GMT+0200 (EET)')
-  t.equal(instadate.dateString(d), 'Mon Jan 18 2016');
-  t.end();
-});
-
 test('min', function (t) {
   var d1 = new Date('Mon Jan 18 2016 13:07:17 GMT+0200 (EET)');
   var d2 = new Date('Mon Jan 18 2016 12:07:17 GMT+0200 (EET)');


### PR DESCRIPTION
Changed `isoDateString` to work correctly with UTC+13, UTC+14 & UTC-12. Removed `dateString` function.